### PR TITLE
Handle multiple -I and cflags not starting with -I

### DIFF
--- a/flycheck-pkg-config.el
+++ b/flycheck-pkg-config.el
@@ -1,6 +1,6 @@
 ;;; flycheck-pkg-config.el --- configure flycheck using pkg-config  -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2016  
+;; Copyright (C) 2016
 
 ;; Author: Wilfred Hughes <me@wilfred.me.uk>
 ;; Keywords: flycheck
@@ -53,11 +53,11 @@ Raises an error if pkg-config can't find any paths for this library."
   (let* (;; Find the include flags, e.g. "-I/usr/lib/foo"
          (pkgconfig-cmd (format "pkg-config --cflags %s" library-name))
          (cc-args (s-trim (shell-command-to-string pkgconfig-cmd))))
-    (if (s-starts-with? "-I" cc-args)
+    (if (s-contains? "-I" cc-args)
         ;; pkg-config has found a library with this name.
-        (let* ((include-args (s-split " " cc-args))
-               (lib-paths (--map (s-chop-prefix "-I" it) include-args)))
-          lib-paths)
+	(let (ret)
+	  (dolist (x (s-split " " cc-args) ret)
+	    (if (s-starts-with? "-I" x) (setq ret (cons (s-chop-prefix "-I" x) ret)))))
       (user-error cc-args))))
 
 ;;;###autoload


### PR DESCRIPTION
For example:
    On NixOS `pkg-config --cflags SDL2_ttf` evals to
    `-D_REENTRANT -I/nix/store/96a2hgf309g2y6sxc4d6k1mpli2cd6l3-SDL2-2.0.3/include/SDL2 -I/nix/store/pknnhxfkqlzqpcndnchfsw1kmx5bk0fx-SDL2_ttf-2.0.14/include/SDL2`

In the past, this would fail immediately because the returned value does
not begin with `-I`. Even if the `-D_REENTRANT` was chopped from the
list, then only the first include path would be used.
